### PR TITLE
Replace empty json used on fresh new mindmap by a minimal one 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,113 +1,123 @@
 Mindmap module for Moodle
 ------------------------
-by Tõnis Tartes
+*by Tõnis Tartes*
 
 This Mindmap module allows you to create and save simple mindmaps from within moodle.
 
-Quick install instructions:
+**Quick install instructions:**
 
-- Copy this "/mindmap"-Folder and place it in your /mod directory
+- Copy this `/mindmap`-Folder and place it in your `/mod` directory
 - Go to your admin area and "Notifications"
 - That's it
 
 Have fun!
 
-Thanks goes to FatCow Webhosting for the new Mindmap icon. 
+Thanks goes to FatCow Webhosting for the new Mindmap icon.
 License: Creative Commons(Attribution 3.0 United States)
 
-// INSTRUCTIONS
+# INSTRUCTIONS
 Use the main buttons from mindmap taskbar to create mindmaps.
+
 + If you double click anywhere in the empty space you can start connecting lines between nodes! Helps to save a few moves.
 
-// 26.10.2021 - 2021102601 version
+# Release notes
+## 14.09.2022 - 2022091400 version
++ Replace empty json used on fresh new mindmap by a minimal one to avoid some http server to interpret it as an error.
++ Add monoicon svg version for Moodle 4.x
+
+
+## 26.10.2021 - 2021102601 version
 + Removing default languages supported by VisJS, caused not beeing able to customize strings in the VisJS supported languages from Moodle.
 + Added Spanish / Castilian translation. Thanks Marcelo Audisio!
 + Added resetting function. All the mindmaps can be cleared of content when resetting course.
 + Removing SWF support. If you require swf migration then from github branch 'swf_convert' has that functionality.
 
-// 31.03.2020 - 2021032210 version
+## 31.03.2020 - 2021032210 version
 + VisJS supports default languages 'en', 'de', 'es', 'it', 'fr', 'cz', 'nl', 'ru', 'cn', 'ua'.
 + Now you can also translate VisJS labels inside the edit window in your own language.
 + Added new translatable strings.
 
-// 30.03.2020 - 2021032208 version
+## 30.03.2020 - 2021032208 version
 + Max zoom out level
 + Max zoom in level
 + Zoom reset button
 
-// 25.03.2020 - 2021032207 version
+## 25.03.2020 - 2021032207 version
 + Keyboard "Insert" key helps to add new nodes to mindmap.
 + Keyboard "Delete" key enables to instantly delete selected nodes or edges.
 + Coding style fixes
 + Minor locking bug fix
 
-// 05.03.2020 update
-+ Moved from Flash to JS - Thanks to vis.js library! - https://visjs.org/
+## 05.03.2020 update
++ Moved from Flash to JS - Thanks to vis.js library! - https:## visjs.org/
 + Javascript version is supported in all browser!
 + New version supports different shapes.
 + Mobile friendly.
 + Ability to review and convert from old Flash mindmap to JS based mindmap.
 + In future Flash Conversion option will be dropped with database field holding flash data!!!
+
 NB! Conversion from flash data might still hold a few bugs. Always check your data!
+
 - Dropped Moodle 1.x backup/restore support.
 
 
-//25.04.2019 - version 2019042500
-+Version update
-+Fixing some deprecated functions
+## 25.04.2019 - version 2019042500
++ Version update
++ Fixing some deprecated functions
 
-//20.10.2017 - version 2017102000
-+Moodle 3.0+ compatibliy
-+Code cleanup.
-+Added getflash button. Clicking it will prompt whether to allow flash or not in chrome.
+## 20.10.2017 - version 2017102000
++ Moodle 3.0+ compatibility
++ Code cleanup.
++ Added getflash button. Clicking it will prompt whether to allow flash or not in chrome.
 
-//09.06.2014 - version 2014060900
-+Moodle 2.7 compatiblity with new logging api
-This version is compatible with Moodle 2.6 and up. 
+## 09.06.2014 - version 2014060900
++ Moodle 2.7 compatiblity with new logging api
+This version is compatible with Moodle 2.6 and up.
 Please download older version for Moodle 2.5 and below.
 
-//13.05.2014 - version 2014051300
-+Fixed minor logging messages
-+Fixed notice in mindmap index
-+On page reload mindmap field sizes according to window
+## 13.05.2014 - version 2014051300
++ Fixed minor logging messages
++ Fixed notice in mindmap index
++ On page reload mindmap field sizes according to window
 
-//12.02.2014 - version 2014021200
-+fixed context notice for Moodle 2.6
-+added completion ability
-+Bump to Moodle 2.6 version
+## 12.02.2014 - version 2014021200
++ fixed context notice for Moodle 2.6
++ added completion ability
++ Bump to Moodle 2.6 version
 
-//06.09.2013 - version 2013090600
-+Removed old upgrade codes(2007040100)
-+New default icon with transparent background
-+Bump to Moodle 2.5 version
+## 06.09.2013 - version 2013090600
++ Removed old upgrade codes(2007040100)
++ New default icon with transparent background
++ Bump to Moodle 2.5 version
 
-//01.03.2013 - version 2013030100
+## 01.03.2013 - version 2013030100
 Teacher can enable locking, so that multiple students cannot edit a mindmap at the same time.
 This caused problems with saving xml data.
 NB! All mindmaps will have locking enabled by default after upgrade.
-+Locking functionality.
++ Locking functionality.
 
-//09.10.2012 - version 2012100900
-+Modified viewer.swf and fixed IE compatiblity issue
+## 09.10.2012 - version 2012100900
++ Modified viewer.swf and fixed IE compatiblity issue
 
-//04.07.2012 - version 2012070400
-+Minor fixes
+## 04.07.2012 - version 2012070400
++ Minor fixes
 
-//13.06.2012 - version 2012061300
-+Refactored code
+## 13.06.2012 - version 2012061300
++ Refactored code
 
-//10.06.2012 - version 2012061000
-+adding access.php
+## 10.06.2012 - version 2012061000
++ adding access.php
 
-//17.05.2012 - version 2012032300
-+Fixed some errors when upgrading from 1.9 to 2.x
+## 17.05.2012 - version 2012032300
++ Fixed some errors when upgrading from 1.9 to 2.x
 
-//13.01.2012 - version 2012011300
-+Added licences
+## 13.01.2012 - version 2012011300
++ Added licences
 
-//12.09.2011 - version 2011091200
+## 12.09.2011 - version 2011091200
 Everythings the same as the old one, except the backup & restore functionality.
-+Fixed the editable box
-+Added a Description field
-+Moodle 2.x Backup/Restore
-+Moodle 1.9>Moodle 2.x Restore
+
++ Fixed the editable box
++ Added a Description field
++ Moodle 2.x Backup/Restore
++ Moodle 1.9>Moodle 2.x Restore

--- a/lib.php
+++ b/lib.php
@@ -262,6 +262,9 @@ function mindmap_supports($feature) {
             return false;
         case FEATURE_BACKUP_MOODLE2:
             return true;
+        /* Moodle 4.x icons */
+        case FEATURE_MOD_PURPOSE:
+            return MOD_PURPOSE_COLLABORATION;
         default:
             return null;
     }

--- a/mindmapdata.php
+++ b/mindmapdata.php
@@ -41,4 +41,15 @@ if ($id) {
 require_login($course->id);
 
 // Get old flash data for conversion
-echo $mindmap->mindmapdata;
+if ($mindmap->mindmapdata) {
+    echo $mindmap->mindmapdata;
+} else {
+    echo '[{"x": 400,
+        "y": 370,
+        "id": "moodle",
+        "label": "Moodle",
+        "font": {"color": "#fff"},
+        "color": {"background": "#c45400"},
+        "connections": []
+    }]';
+}

--- a/pix/monologo.svg
+++ b/pix/monologo.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.5.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1"
+	 id="svg3066" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:svg="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 24 24"
+	 style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<style type="text/css">
+	.st0{opacity:0.5;}
+	.st1{opacity:0.8;}
+	.st2{opacity:0.7;}
+	.st3{fill:#FFFFFF;}
+</style>
+<path id="filament" class="st0" d="M10,9v1h5V9H10z"/>
+<path id="wire" d="M11,19v-6L9,9l1-1l2,4h1l2-4l1,1l-2,4v6h-1v-6h-1v6H11z"/>
+<path id="glass" class="st1" d="M8,19c0-8-4-7-4-12
+	c0-4,4-7,8-7s8,3,8,7c0,5-4,4-4,12c0,0.3-1,0.3-1,0c0-9,4-7,4-12c0-3-3-6-7-6S5,4,5,7c0,5,4,3,4,12H8z"/>
+<path id="glint" class="st2" d="M6,7c-0.9-2.4,3.6-6.1,6-5
+	c0.3,0.1,0.3,1,0,1c-2,0-5,2-5,4C7,7.3,6.1,7.3,6,7z"/>
+<path id="base" d="M8,18v1.7V21v0.3c0,0.9,0.9,1.7,2,1.7h0.2c0.3,0.6,1,1,1.8,1s1.5-0.4,1.8-1H14c1.1,0,2-0.7,2-1.7V21v-1.3V18
+	h-2h-4H8z"/>
+<path id="thread1" class="st3" d="M16,18.5l-8,1.2v1l8-1.2V18.5z"/>
+<path id="thread2" class="st3" d="M16,20.3l-8,1.3c0.1,0.4,0.2,0.7,0.5,0.9l7.4-1.2V21V20.3z"/>
+</svg>

--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2021102601;  // The current module version (Date: YYYYMMDDXX).
+$plugin->version = 2022091400;  // The current module version (Date: YYYYMMDDXX).
 $plugin->requires = 2013111800; // Requires Moodle 2.6.
 $plugin->cron = 0;           // Period for cron to check this module (secs).
 $plugin->component = 'mod_mindmap'; // Full name of the plugin (used for diagnostics).
 
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = "2021102601"; // User-friendly version number.
+$plugin->release = "2022091400"; // User-friendly version number.


### PR DESCRIPTION
Hello!
First, I thank you for this mod :)
We detected a bug on our servers preventing this module to work : when it sends nothing instead of an empty json, some load balancing servers are detecting this as an error.

With this patch, it will always send a well formatted json.

I've also added a monoicon svg version for Moodle 4.x