### PR TITLE
Replace jQuery call with vanilla JS.

### DIFF
--- a/module.js
+++ b/module.js
@@ -41,7 +41,7 @@ M.mod_mindmap.user_selector = function (Y) {
     // Select users with onclick.
     Y.all('#mindmap_select').on('change', function() {
         var newurl = window.location.href.split('&');
-        var userid = $('#mindmap_select').find(":selected").val();
+        var userid = document.getElementById('mindmap_select').value;
         window.location.href = newurl[0]+'&userid='+userid;
     });
 }


### PR DESCRIPTION
Fixes an issue where switching between users of an individual mindmap raises a JS error for the missing $ function.